### PR TITLE
Fix tailwind config plugin imports

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
+import typography from "@tailwindcss/typography";
 
 export default {
   darkMode: ["class"],
@@ -86,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
+  plugins: [animate, typography],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- fix `tailwind.config.ts` so it uses ES module imports

## Testing
- `npm run check` *(fails: no inputs were found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe62aaf088326b31a12a11d959717